### PR TITLE
kernel-ci: blacklist mustang big endian booting from v3.10 kernels

### DIFF
--- a/lava-kernel-ci-job-creator.py
+++ b/lava-kernel-ci-job-creator.py
@@ -554,6 +554,7 @@ apm_mustang = {'device_type': 'mustang',
                                  'v3.12',
                                  'v3.14',
                                  'lsk-v3.14'],
+               'be_blacklist': ['v3.10'],
                'lpae': False,
                'fastboot': False}
 
@@ -809,6 +810,10 @@ def create_jobs(base_url, kernel, plans, platform_list, targets, priority):
                     print '%s has been blacklisted. Skipping JSON creation' % kernel_version
                 elif any([x for x in device['nfs_blacklist'] if x in kernel_version]) \
                         and plan in ['boot-nfs', 'boot-nfs-mp']:
+                    print '%s has been blacklisted. Skipping JSON creation' % kernel_version
+                elif 'be_blacklist' in device \
+                        and any([x for x in device['be_blacklist'] if x in kernel_version]) \
+                        and plan in ['boot-be']:
                     print '%s has been blacklisted. Skipping JSON creation' % kernel_version
                 elif targets is not None and device_type not in targets:
                     print '%s device type has been omitted. Skipping JSON creation.' % device_type


### PR DESCRIPTION
lsk-v3.10 big endian boot test on mustang is failing. LSK team commented
that we didn't do much for arm64 big endian in v3.10 and suggested to
blacklist the test from v3.10.

Tested this patch with lsk-v3.10 and lsk-v3.14 builds. BE boot test job
was skipped on v3.10 successfully, and created on v4.10 as before.

Signed-off-by: Chase Qi chase.qi@linaro.org
