### PR TITLE
Standard boots should not have a timeout of 5 hours

### DIFF
--- a/templates/boot/generic-arm-dtb-kernel-ci-boot-template.json
+++ b/templates/boot/generic-arm-dtb-kernel-ci-boot-template.json
@@ -35,5 +35,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }


### PR DESCRIPTION
I have a kernelci job on my jetson tk1 which is "going beserk".
Lava is not timing out the job because it hangs trying to run the test command "mount",
so its sitting there spamming kernel debug for 5 hours or until I cancel it.
How about 10 minutes?
