### PR TITLE
Change lava job timeouts to 600 seconds

### DIFF
--- a/templates/boot/cfe-arm-dtb-kernel-ci-boot-template.json
+++ b/templates/boot/cfe-arm-dtb-kernel-ci-boot-template.json
@@ -36,5 +36,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }

--- a/templates/boot/generic-arm-kernel-ci-boot-template.json
+++ b/templates/boot/generic-arm-kernel-ci-boot-template.json
@@ -33,5 +33,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }

--- a/templates/boot/generic-arm64-dtb-kernel-ci-boot-template.json
+++ b/templates/boot/generic-arm64-dtb-kernel-ci-boot-template.json
@@ -35,5 +35,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }

--- a/templates/boot/generic-arm64-dtb-uefi-kernel-ci-boot-template.json
+++ b/templates/boot/generic-arm64-dtb-uefi-kernel-ci-boot-template.json
@@ -36,5 +36,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }

--- a/templates/boot/generic-arm64-kernel-ci-boot-template.json
+++ b/templates/boot/generic-arm64-kernel-ci-boot-template.json
@@ -33,5 +33,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }

--- a/templates/boot/generic-x86-kernel-ci-boot-template.json
+++ b/templates/boot/generic-x86-kernel-ci-boot-template.json
@@ -34,5 +34,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }

--- a/templates/boot/juno-arm64-dtb-kernel-ci-boot-template.json
+++ b/templates/boot/juno-arm64-dtb-kernel-ci-boot-template.json
@@ -35,5 +35,5 @@
     "job_name": "{job_name}",
     "logging_level": "DEBUG",
     "priority": "{priority}",
-    "timeout": 18000
+    "timeout": 600
 }


### PR DESCRIPTION
5 hours is far too long to wait for a runaway job to finish
so lets say 10 minutes.
