### PR TITLE
Add lab-pengutronix boards mapping

### DIFF
--- a/lava-kernel-ci-job-creator.py
+++ b/lava-kernel-ci-job-creator.py
@@ -752,6 +752,50 @@ x86_kvm = {'device_type': 'kvm',
            'lpae': False,
            'fastboot': False}
 
+imx6dl_riotboard = {
+  'device_type': 'imx6dl-riotboard',
+  'templates': [
+    'generic-arm-dtb-kernel-ci-boot-template.json',
+    'generic-arm-dtb-kernel-ci-boot-nfs-template.json',
+    'generic-arm-dtb-kernel-ci-boot-nfs-mp-template.json',
+    'generic-arm-dtb-kernel-ci-ltp-mm-template.json',
+    'generic-arm-dtb-kernel-ci-ltp-syscalls-template.json',
+    'generic-arm-dtb-kernel-ci-kselftest-template.json',
+    'generic-arm-dtb-kernel-ci-hackbench-template.json'
+  ],
+  'defconfig_blacklist': [
+    'arm-imx_v4_v5_defconfig',
+    'arm-multi_v5_defconfig',
+    'arm-allmodconfig'
+  ],
+  'kernel_blacklist': [],
+  'nfs_blacklist': [],
+  'lpae': False,
+  'fastboot': False
+}
+
+imx53_qsbr = {
+  'device_type': 'imx53-qsbr',
+  'templates': [
+    'generic-arm-dtb-kernel-ci-boot-template.json',
+    'generic-arm-dtb-kernel-ci-boot-nfs-template.json',
+    'generic-arm-dtb-kernel-ci-boot-nfs-mp-template.json',
+    'generic-arm-dtb-kernel-ci-ltp-mm-template.json',
+    'generic-arm-dtb-kernel-ci-ltp-syscalls-template.json',
+    'generic-arm-dtb-kernel-ci-kselftest-template.json',
+    'generic-arm-dtb-kernel-ci-hackbench-template.json'
+  ],
+  'defconfig_blacklist': [
+    'arm-imx_v4_v5_defconfig',
+    'arm-multi_v5_defconfig',
+    'arm-allmodconfig'
+  ],
+  'kernel_blacklist': [],
+  'nfs_blacklist': [],
+  'lpae': False,
+  'fastboot': False
+}
+
 device_map = {'bcm2835-rpi-b-plus.dtb': [bcm2835_rpi_b_plus],
               'bcm4708-smartrg-sr400ac.dtb': [bcm4708_smartrg_sr400ac],
               'armada-370-mirabox.dtb': [armada_370_mirabox],
@@ -805,7 +849,9 @@ device_map = {'bcm2835-rpi-b-plus.dtb': [bcm2835_rpi_b_plus],
               'fsl-ls2080a-simu.dtb': [fsl_ls2080a_simu],
               'fsl-ls2080a-rdb.dtb': [fsl_ls2080a_rdb],
               'x86': [x86, minnowboard_max_E3825, x86_atom330],
-              'x86-kvm': [x86_kvm]}
+              'x86-kvm': [x86_kvm],
+              'imx6dl-riotboard.dtb': [imx6dl_riotboard],
+              'imx53-qsrb.dtb': [imx53_qsbr]}
 
 parse_re = re.compile('href="([^./"?][^"?]*)"')
 


### PR DESCRIPTION
- Mapped dtbs to their device type.
- Added new device type for imx6dl-riotboard and imx53-qsbr
  based on the imx6q-wandboard.
