### PR TITLE
Improve the speed of job creation and submission

### DIFF
--- a/lava-job-runner.py
+++ b/lava-job-runner.py
@@ -194,10 +194,16 @@ def submit_jobs(connection, server, bundle_stream=None):
             continue
 
 
-def load_jobs(top):
-    for root, dirnames, filenames in os.walk(top):
-        for filename in fnmatch.filter(filenames, '*.json'):
-            job_map[os.path.join(root, filename)] = None
+def load_jobs(top, plans):
+    if plans:
+        for plan in plans:
+            for root, dirnames, filenames in os.walk(top + '/' + plan):
+                for filename in fnmatch.filter(filenames, '*.json'):
+                    job_map[os.path.join(root, filename)] = None
+    else:
+        for root, dirnames, filenames in os.walk(top):
+            for filename in fnmatch.filter(filenames, '*.json'):
+                job_map[os.path.join(root, filename)] = None
 
 
 def retrieve_jobs(jobs):
@@ -257,11 +263,12 @@ def main(args):
     if config.get("repo"):
         retrieve_jobs(config.get("repo"))
 
+    plans = config.get("plans")
     if config.get("jobs"):
-        load_jobs(config.get("jobs"))
+        load_jobs(config.get("jobs"), plans)
         print "Loading jobs from top folder " + str(config.get("jobs"))
     else:
-        load_jobs(os.getcwd())
+        load_jobs(os.getcwd() + '/jobs', plans)
 
     start_time = time.time()
 
@@ -301,5 +308,6 @@ if __name__ == '__main__':
     parser.add_argument("--poll", help="poll the submitted LAVA jobs, dumps info into specified json")
     parser.add_argument("--timeout", type=int, default=-1, help="polling timeout in seconds. default is -1.")
     parser.add_argument('--bisect', help="bisection mode, returns 1 on any job failures", action='store_true')
+    parser.add_argument("--plans", nargs='+', help="test plan to create jobs for")
     args = vars(parser.parse_args())
     main(args)

--- a/lava-kernel-ci-job-creator.py
+++ b/lava-kernel-ci-job-creator.py
@@ -87,7 +87,7 @@ def create_jobs(base_url, kernel, plans, platform_list, targets, priority):
                 else:
                     for template in device_templates:
                         job_name = tree + '-' + kernel_version + '-' + defconfig[:100] + '-' + platform_name + '-' + device_type + '-' + plan
-                        job_json = directory + '/' + job_name + '.json'
+                        job_json = directory + '/' + plan + '/' + job_name + '.json'
                         template_file = cwd + '/templates/' + plan + '/' + str(template)
                         if os.path.exists(template_file):
                             with open(job_json, 'wt') as fout:
@@ -143,7 +143,7 @@ def create_jobs(base_url, kernel, plans, platform_list, targets, priority):
                                         else:
                                             tmp = tmp.replace('{priority}', 'high')
                                         fout.write(tmp)
-                            print 'JSON Job created: jobs/%s' % job_name
+                            print 'JSON Job created: jobs/%s/%s' % (plan, job_name)
 
 
 def walk_url(url, plans=None, arch=None, targets=None, priority=None):
@@ -228,10 +228,11 @@ def walk_url(url, plans=None, arch=None, targets=None, priority=None):
 def main(args):
     global directory
     config = configuration.get_config(args)
+    plans = config.get("plans")
     if config.get("jobs"):
-        directory = setup_job_dir(config.get("jobs"))
+        directory = setup_job_dir(config.get("jobs"), plans)
     else:
-        directory = setup_job_dir(os.getcwd() + '/jobs')
+        directory = setup_job_dir(os.getcwd() + '/jobs', plans)
     print 'Scanning %s for kernel information...' % config.get("url")
     walk_url(config.get("url"), config.get("plans"), config.get("arch"), config.get("targets"), config.get("priority"))
     print 'Done scanning for kernel information'

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -7,13 +7,17 @@ import json
 import ssl
 
 
-def setup_job_dir(arg):
+def setup_job_dir(arg, subs=[]):
     print 'Setting up job output directory at: ' + str(arg)
     if not os.path.exists(arg):
         os.makedirs(arg)
+        for sub in subs:
+            os.makedirs(arg + "/" + sub)
     else:
         shutil.rmtree(arg)
         os.makedirs(arg)
+        for sub in subs:
+            os.makedirs(arg + "/" + sub)
     directory = arg
     print 'Done setting up job output directory'
     return directory


### PR DESCRIPTION
Write jobs to subdirectories per plan so they can be submitted multiple times without be recreated. The job runner needs to be told what plans to submit.

The layout of tbaker-kboot-bot will need to be changed.
