### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ You should now add the device\_type and device from your LAVA admin panel. If yo
 
 To add your board to KernelCI, you will have to modify two files:
 
-- lava-kernel-ci-job-creator.py:
+- lib/device\_map.py:
 
 You need to create a dictionary for your board as following:
 
 ```
 armada_388_clearfog = {'device_type': 'armada-388-clearfog',
                     'templates': ['generic-arm-dtb-kernel-ci-boot-template.json'],
+		    'kernel_defconfig_blacklist': [],
                     'defconfig_blacklist': ['arm-allmodconfig'],
                     'kernel_blacklist': [],
                     'nfs_blacklist': [],
@@ -111,6 +112,8 @@ armada_388_clearfog = {'device_type': 'armada-388-clearfog',
 `armada-388-clearfog` is the name of your LAVA device\_type and, as strongly advised above, should be the name of the board's dtb in kernel sources.
 
 The `templates` array represents the templates used to create jobs for the specified board. All templates can be found in the subdirectory templates. For example, here, we want to test with the template `generic-arm-dtb-kernel-ci-boot-template.json` which is located in templates/boot directory. This template will be filled by lava-kernel-ci-job-creator.py only when one of the plans is `boot` (the name of the parent directory of the template).
+
+The `kernel_defconfig_blacklist` array is an array of dictionaries containing two keys: `kernel_version` and `defconfig`. When lava-kernel-ci-job-creator.py creates test jobs, it will not create a test job for the defconfig of the kernel version.
 
 The `nfs_blacklist` array is an array of substrings of a kernel version you should not boot with NFS.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Examples:
 ```
 The generated jobs can be found in the jobs directory. You can override the default behaviour by passing the output directory in the `--jobs` parameter.
 
+The different possible plans are the name of directories in the template directory.
 
 ## Usage instructions for lava-job-runner.py:
 This command line tool will submit all LAVA jobs in the current working directory.
@@ -109,7 +110,7 @@ armada_388_clearfog = {'device_type': 'armada-388-clearfog',
 
 `armada-388-clearfog` is the name of your LAVA device\_type and, as strongly advised above, should be the name of the board's dtb in kernel sources.
 
-The `templates` array represents the templates used to create jobs for the specified board. All templates can be found in the subdirectory templates.
+The `templates` array represents the templates used to create jobs for the specified board. All templates can be found in the subdirectory templates. For example, here, we want to test with the template `generic-arm-dtb-kernel-ci-boot-template.json` which is located in templates/boot directory. This template will be filled by lava-kernel-ci-job-creator.py only when one of the plans is `boot` (the name of the parent directory of the template).
 
 The `nfs_blacklist` array is an array of substrings of a kernel version you should not boot with NFS.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Examples:
 ## Usage instructions for lava-kernel-ci-job-creator.py:
 This command line tool will create LAVA boot test jobs for various architectures, and platforms.
 ```
-./lava-kernel-ci-job-creator.py [-h] --plans PLANS [PLANS ...] [--arch ARCH] [--targets TARGETS [TARGETS ...]] url
+./lava-kernel-ci-job-creator.py [-h] [--jobs JOBS] --plans PLANS [PLANS ...] [--arch ARCH] [--targets TARGETS [TARGETS ...]] url
 ```
 Examples:
 ```
@@ -39,13 +39,13 @@ Examples:
 # Create only LAVA boot test jobs for a specific build and targets.
 ./lava-kernel-ci-job-creator.py http://storage.kernelci.org/next/next-20150114/ --plans boot --targets mustang odroid-xu3
 ```
-The generated jobs can be found in the jobs directory.
+The generated jobs can be found in the jobs directory. You can override the default behaviour by passing the output directory in the `--jobs` parameter.
 
 
 ## Usage instructions for lava-job-runner.py:
 This command line tool will submit all LAVA jobs in the current working directory.
 ```
-./lava-job-runner.py [-h] [--stream STREAM] [--repo REPO] [--poll POLL]
+./lava-job-runner.py [-h] [--stream STREAM] [--repo REPO] [--poll POLL] [--jobs JOBS]
 ```
 Examples:
 
@@ -59,6 +59,7 @@ Examples:
 # Submit and poll all LAVA jobs in the current working directory to a specific server, bundle stream. Once the results have been obtained, store the results in a JSON encoded file for use later with the dashboard reporting tool.
 ./lava-job-runner.py <username> <lava token> http://my.lavaserver.com/RPC2/ --stream /anonymous/mybundle/ --boot results/kernel-ci.json --lab <lab-id> --api http://api.kernelci.org --token <dashboard token>
 ```
+It will run jobs in the current directory. You can override the default behaviour by passing the jobs directory in the `--jobs` parameter.
 
 ## Usage instructions for lava-report.py:
 This command line tool will report the results of LAVA jobs given a JSON results file.

--- a/README.md
+++ b/README.md
@@ -143,9 +143,19 @@ The first `armada-388-clearfog` is the name of of your LAVA device\_type while t
 
 `mvebu` is the SoC name of the board and also where the board will be found in KernelCI dashboard.
 
+### Test the board
+
+KernelCI only wants to detect new regressions in the Linux kernel. If, when adding a board to KernelCI, the board is known to not be working on few kernel versions or configurations, you must blacklist those kernel versions or configurations in your board dictionary. You can remove the blacklisting of these boards (or target more precisely impacted kernel versions or configurations) once the kernel is known to be working in the version and configuration which are blacklisted.
+
+KernelCI basically asks you to test your board on all stable releases and the mainline releases (at least the last one). You can perform these tests with the following, plans being set to all templates used by this board:
+```
+./lava-kernel-ci-job-creator.py https://storage.kernelci.org/stable --jobs stable --plans boot --targets armada-388-clearfog
+./lava-kernel-ci-job-creator.py https://storage.kernelci.org/mainline --jobs mainline --plans boot --targets armada-388-clearfog
+./lava-job-runner.py --username <lava username> --token <lava token> --server <http://lava-server/RPC2> --stream /anonymous/mybundle/ --jobs stable
+./lava-job-runner.py --username <lava username> --token <lava token> --server <http://lava-server/RPC2> --stream /anonymous/mybundle/ --jobs mainline
+```
+
 ### Add your lab to KernelCI
 If you did everything as explained above, send them a mail with the authentication token for user `kernel-ci` and make your LAVA instance (at least the XMLRPC API which is located at /RPC2) available from Internet.
-
-Before sending the mail, test your board by running lava-kernel-ci-job-creator.py then lava-job-runner.py.
 
 If you want to add a board to your lab which already exists in KernelCI, make sure your LAVA device\_type matches the name used in lava-kernel-ci-job-creator.py.


### PR DESCRIPTION
This updates the README with the following:
- update command line examples with `--jobs` parameter,
- explain how templates work (where to find them and relation between template in board dictionary and `--plans` in lava-kernel-ci-job-creator.py,
- update board dictionary example with `kernel_defconfig_blacklist`,
- add section on testing board with stable and mainline releases before opening a Pull Request;
