### PR TITLE
boot-kvm: add a working rootfs

### DIFF
--- a/templates/boot-kvm-uefi/generic-arm64-boot-kvm-uefi-template.json
+++ b/templates/boot-kvm-uefi/generic-arm64-boot-kvm-uefi-template.json
@@ -39,7 +39,7 @@
             "dtb": "{dtb_url}",
             "kernel": "{kernel_url}",
             "overlays": ["{modules_url}"],
-            "nfsrootfs": "http://releases.linaro.org/ubuntu/images/nano-arm64/15.12/linaro-vivid-nano-20151215-114.tar.gz",
+            "nfsrootfs": "http://releases.linaro.org/debian/images/developer-arm64/16.07/linaro-jessie-developer-20160722-88.tar.gz",
             "target_type": "ubuntu",
             "role": "host"
         }

--- a/templates/boot-kvm/generic-arm-boot-kvm-template.json
+++ b/templates/boot-kvm/generic-arm-boot-kvm-template.json
@@ -39,7 +39,7 @@
             "dtb": "{dtb_url}",
             "kernel": "{kernel_url}",
             "overlays": ["{modules_url}"],
-            "nfsrootfs": "http://releases.linaro.org/ubuntu/images/nano/15.12/linaro-vivid-nano-20151215-714.tar.gz",
+            "nfsrootfs": "http://releases.linaro.org/debian/images/developer-armhf/16.06/linaro-jessie-developer-20160620-25.tar.gz",
             "target_type": "ubuntu",
             "role": "host"
         }

--- a/templates/boot-kvm/generic-arm64-boot-kvm-template.json
+++ b/templates/boot-kvm/generic-arm64-boot-kvm-template.json
@@ -39,7 +39,7 @@
             "dtb": "{dtb_url}",
             "kernel": "{kernel_url}",
             "overlays": ["{modules_url}"],
-            "nfsrootfs": "http://releases.linaro.org/ubuntu/images/nano-arm64/15.12/linaro-vivid-nano-20151215-114.tar.gz",
+            "nfsrootfs": "http://releases.linaro.org/debian/images/developer-arm64/16.07/linaro-jessie-developer-20160722-88.tar.gz",
             "target_type": "ubuntu",
             "role": "host"
         }


### PR DESCRIPTION
Switch to linaro debian jessie as rootfs so we get a working and up-to
date qemu. Temporary measure until we bake a golden rootfs for kvm
testing. Succesful test job at:

host https://validation.linaro.org/scheduler/job/1091781/log_file
guest https://validation.linaro.org/scheduler/job/1091782/log_file
