### PR TITLE
KernelCI staging 20170621

### DIFF
--- a/jenkins/lava-boot-v1.sh
+++ b/jenkins/lava-boot-v1.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -x 
+
+if [ ${LAB} = "lab-tbaker" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_TBAKER} --server http://lava.kernelci.org/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_TBAKER} --api https://api.kernelci.org
+elif [ ${LAB} = "lab-mhart" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_MHART} --server http://lava.streamtester.net/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_MHART} --api https://api.kernelci.org
+elif [ ${LAB} = "lab-collabora" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --priority medium
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_COLLABORA} --server https://lava.collabora.co.uk/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_COLLABORA} --api https://api.kernelci.org/
+elif [ ${LAB} = "lab-cambridge" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --targets mustang hi3716cv200 juno beaglebone-black kvm d01 arndale highbank
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_CAMBRIDGE} --server https://validation.linaro.org/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_CAMBRIDGE} --api https://api.kernelci.org/
+elif [ ${LAB} = "lab-baylibre-seattle" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_BAYLIBRE_SEATTLE} --server http://lava.ished.com/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BAYLIBRE_SEATTLE} --api https://api.kernelci.org/
+elif [ ${LAB} = "lab-embeddedbits" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --targets panda-es zynq-zc702 omap3-overo-storm-tobi imx6q-sabrelite
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_EMBEDDED_BITS} --server http://kernelci.embedded-bits.co.uk/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_EMBEDDED_BITS} --api https://api.kernelci.org
+elif [ ${LAB} = "lab-jsmoeller" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-job-runner.py --username kernelciuser --token ${LAVA_TOKEN_JSMOELLER} --server https://88.198.106.157/mylava/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_JSMOELLER} --api https://api.kernelci.org
+elif [ ${LAB} = "lab-baylibre" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_BAYLIBRE} --server http://lava.baylibre.com:10080/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BAYLIBRE} --api https://api.kernelci.org
+elif [ ${LAB} = "lab-pengutronix" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_PENGUTRONIX} --server https://hekla.openlab.pengutronix.de/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_PENGUTRONIX} --api https://api.kernelci.org
+elif [ ${LAB} = "lab-free-electrons" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --priority medium
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_FREE_ELECTRONS} --server https://lab.free-electrons.com/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_FREE_ELECTRONS} --api https://api.kernelci.org
+elif [ ${LAB} = "lab-broonie" ]; then
+	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_BROONIE} --server http://lava.sirena.org.uk/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BROONIE} --api https://api.kernelci.org
+fi

--- a/jenkins/lava-boot-v1.sh
+++ b/jenkins/lava-boot-v1.sh
@@ -3,47 +3,47 @@
 set -x 
 
 if [ ${LAB} = "lab-tbaker" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_TBAKER} --server http://lava.kernelci.org/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_TBAKER} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_TBAKER} --api ${API}
 elif [ ${LAB} = "lab-mhart" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_MHART} --server http://lava.streamtester.net/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_MHART} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_MHART} --api ${API}
 elif [ ${LAB} = "lab-collabora" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --priority medium
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --priority medium
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_COLLABORA} --server https://lava.collabora.co.uk/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_COLLABORA} --api https://api.kernelci.org/
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_COLLABORA} --api ${API}
 elif [ ${LAB} = "lab-cambridge" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --targets mustang hi3716cv200 juno beaglebone-black kvm d01 arndale highbank
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --targets mustang hi3716cv200 juno beaglebone-black kvm d01 arndale highbank
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_CAMBRIDGE} --server https://validation.linaro.org/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_CAMBRIDGE} --api https://api.kernelci.org/
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_CAMBRIDGE} --api ${API}
 elif [ ${LAB} = "lab-baylibre-seattle" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_BAYLIBRE_SEATTLE} --server http://lava.ished.com/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000	
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BAYLIBRE_SEATTLE} --api https://api.kernelci.org/
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BAYLIBRE_SEATTLE} --api ${API}
 elif [ ${LAB} = "lab-embeddedbits" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --targets panda-es zynq-zc702 omap3-overo-storm-tobi imx6q-sabrelite
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --targets panda-es zynq-zc702 omap3-overo-storm-tobi imx6q-sabrelite
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_EMBEDDED_BITS} --server http://kernelci.embedded-bits.co.uk/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_EMBEDDED_BITS} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_EMBEDDED_BITS} --api ${API}
 elif [ ${LAB} = "lab-jsmoeller" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
 	python lava-job-runner.py --username kernelciuser --token ${LAVA_TOKEN_JSMOELLER} --server https://88.198.106.157/mylava/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 4000
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_JSMOELLER} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_JSMOELLER} --api ${API}
 elif [ ${LAB} = "lab-baylibre" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_BAYLIBRE} --server http://lava.baylibre.com:10080/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BAYLIBRE} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BAYLIBRE} --api ${API}
 elif [ ${LAB} = "lab-pengutronix" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_PENGUTRONIX} --server https://hekla.openlab.pengutronix.de/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_PENGUTRONIX} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_PENGUTRONIX} --api ${API}
 elif [ ${LAB} = "lab-free-electrons" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --priority medium
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB} --priority medium
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_FREE_ELECTRONS} --server https://lab.free-electrons.com/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_FREE_ELECTRONS} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_FREE_ELECTRONS} --api ${API}
 elif [ ${LAB} = "lab-broonie" ]; then
-	python lava-kernel-ci-job-creator.py https://storage.kernelci.org/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
+	python lava-kernel-ci-job-creator.py ${STORAGE}/$TREE/$BRANCH/$GIT_DESCRIBE/ --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --arch $ARCH --jobs ${LAB}
 	python lava-job-runner.py --username kernel-ci --token ${LAVA_TOKEN_BROONIE} --server http://lava.sirena.org.uk/RPC2/ --stream /anonymous/kernel-ci/ --poll kernel-ci.json --timeout 2000
-	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BROONIE} --api https://api.kernelci.org
+	python lava-report.py --boot results/kernel-ci.json --lab ${LAB} --token ${API_TOKEN_BROONIE} --api ${API}
 fi

--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -x
+
+if [ ${LAB} = "lab-tbaker" ]; then
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_TBAKER_TOKEN} --server http://lava.kernelci.org/RPC2/
+elif [ ${LAB} = "lab-mhart" ]; then
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_MHART_TOKEN} --server http://lava.streamtester.net/RPC2/
+#elif [ ${LAB} = "lab-cambridge" ]; then
+#	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+#    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_CAMBRIDGE_TOKEN} --server https://validation.linaro.org/RPC2/
+elif [ ${LAB} = "lab-collabora" ]; then
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --priority medium
+    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_COLLABORA_TOKEN} --server https://lava.collabora.co.uk/RPC2/
+elif [ ${LAB} = "lab-baylibre" ]; then
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE} --server http://lava.baylibre.com:10080/RPC2/
+elif [ ${LAB} = "lab-baylibre-seattle" ]; then
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE_SEATTLE} --server http://lava.ished.com/RPC2/
+elif [ ${LAB} = "lab-free-electrons" ]; then
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_FREE_ELECTRONS} --server https://lab.free-electrons.com/RPC2/
+fi    

--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -3,24 +3,24 @@
 set -x
 
 if [ ${LAB} = "lab-tbaker" ]; then
-	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --lab ${LAB}
     python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_TBAKER_TOKEN} --server http://lava.kernelci.org/RPC2/
 elif [ ${LAB} = "lab-mhart" ]; then
-	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --lab ${LAB}
     python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_MHART_TOKEN} --server http://lava.streamtester.net/RPC2/
 #elif [ ${LAB} = "lab-cambridge" ]; then
 #	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
 #    python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_CAMBRIDGE_TOKEN} --server https://validation.linaro.org/RPC2/
 elif [ ${LAB} = "lab-collabora" ]; then
-	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --priority medium
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --priority medium --lab ${LAB}
     python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_COLLABORA_TOKEN} --server https://lava.collabora.co.uk/RPC2/
 elif [ ${LAB} = "lab-baylibre" ]; then
-	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --lab ${LAB}
     python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE} --server http://lava.baylibre.com:10080/RPC2/
 elif [ ${LAB} = "lab-baylibre-seattle" ]; then
-	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --lab ${LAB}
     python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE_SEATTLE} --server http://lava.ished.com/RPC2/
 elif [ ${LAB} = "lab-free-electrons" ]; then
-	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN}
+	python lava-v2-jobs-from-api.py --api ${API} --storage ${STORAGE} --jobs ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans  boot boot-be boot-kvm boot-kvm-uefi boot-nfs boot-nfs-mp --token ${API_TOKEN} --lab ${LAB}
     python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_FREE_ELECTRONS} --server https://lab.free-electrons.com/RPC2/
-fi    
+fi

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -36,12 +36,16 @@ def main(args):
     config = configuration.get_config(args)
     plans = config.get("plans")
     targets = config.get("targets")
-    if config.get("jobs"):
-        job_dir = setup_job_dir(config.get("jobs"))
-    else:
-        job_dir = setup_job_dir(os.getcwd() + '/jobs')
+    lab_name = config.get('lab')
+    job_dir = setup_job_dir(config.get('jobs') or lab_name)
+    token = config.get('token')
     api = config.get('api')
     storage = config.get('storage')
+
+    if not token:
+        raise Exception("No token provided")
+    if not api:
+        raise Exception("No KernelCI API URL provided")
 
     arch = args.get('arch')
     plans = args.get('plans')
@@ -50,7 +54,7 @@ def main(args):
     tree = args.get('tree')
     kernel = tree
     headers = {
-        "Authorization": config.get('token')
+        "Authorization": token,
     }
 
     print "Working on kernel %s/%s" % (tree, branch)
@@ -177,7 +181,8 @@ def main(args):
                                                'priority': args.get('priority'), 'device': device, 'template_file': template_file, 'base_url': base_url, 'endian': endian,
                                                'test_suite': test_suite, 'test_set': test_set, 'test_desc': test_desc, 'test_type': test_type, 'short_template_file': short_template_file,
                                                'arch': arch, 'arch_defconfig': arch_defconfig, 'git_branch': branch, 'git_commit': build['git_commit'], 'git_describe': git_describe,
-                                               'defconfig_base': defconfig_base, 'initrd_url': initrd_url, 'kernel_image': build['kernel_image'], 'dtb_short': dtb, 'nfsrootfs_url': nfsrootfs_url}
+                                               'defconfig_base': defconfig_base, 'initrd_url': initrd_url, 'kernel_image': build['kernel_image'], 'dtb_short': dtb, 'nfsrootfs_url': nfsrootfs_url,
+                                               'callback': args.get('callback'), 'api': api, 'lab_name': lab_name}
                                         jobs.append(job)
             else:
                 print "no kernel_image for %s" % build['defconfig_full']
@@ -200,17 +205,19 @@ if __name__ == '__main__':
     parser.add_argument("--token", help="KernelCI API Token")
     parser.add_argument("--api", help="KernelCI API URL")
     parser.add_argument("--storage", help="KernelCI storage URL")
+    parser.add_argument("--lab", help="KernelCI Lab Name", required=True)
     parser.add_argument("--jobs", help="absolute path to top jobs folder")
-    parser.add_argument("--tree", help="KernelCI build kernel tree")
-    parser.add_argument("--branch", help="KernelCI build kernel branch")
-    parser.add_argument("--describe", help="KernelCI build kernel git describe")
+    parser.add_argument("--tree", help="KernelCI build kernel tree", required=True)
+    parser.add_argument("--branch", help="KernelCI build kernel branch", required=True)
+    parser.add_argument("--describe", help="KernelCI build kernel git describe", required=True)
     parser.add_argument("--config", help="path to KernelCI configuration file")
     parser.add_argument("--section", default="default", help="section in the KernelCI config file")
     parser.add_argument("--plans", nargs='+', required=True, help="test plan to create jobs for")
-    parser.add_argument("--arch", help="specific architecture to create jobs for")
+    parser.add_argument("--arch", help="specific architecture to create jobs for", required=True)
     parser.add_argument("--targets", nargs='+', help="specific targets to create jobs for")
     parser.add_argument("--priority", choices=['high', 'medium', 'low', 'HIGH', 'MEDIUM', 'LOW'],
                         help="priority for LAVA jobs", default='high')
+    parser.add_argument("--callback", help="Add a callback notification to the Job YAML", action="store_true")
     args = vars(parser.parse_args())
     if args:
         main(args)

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -40,6 +40,8 @@ def main(args):
         job_dir = setup_job_dir(config.get("jobs"))
     else:
         job_dir = setup_job_dir(os.getcwd() + '/jobs')
+    api = config.get('api')
+    storage = config.get('storage')
 
     arch = args.get('arch')
     plans = args.get('plans')
@@ -47,8 +49,6 @@ def main(args):
     git_describe = args.get('describe')
     tree = args.get('tree')
     kernel = tree
-    storage = args.get('storage')
-    api = args.get('api')
     headers = {
         "Authorization": config.get('token')
     }
@@ -198,14 +198,14 @@ def jinja_render(job):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--token", help="KernelCI API Token")
-    parser.add_argument("--api", help="KernelCI API URL", default="https://api.kernelci.org")
-    parser.add_argument("--storage", help="KernelCI storage URL", default="https://storage.kernelci.org")
+    parser.add_argument("--api", help="KernelCI API URL")
+    parser.add_argument("--storage", help="KernelCI storage URL")
     parser.add_argument("--jobs", help="absolute path to top jobs folder")
     parser.add_argument("--tree", help="KernelCI build kernel tree")
     parser.add_argument("--branch", help="KernelCI build kernel branch")
     parser.add_argument("--describe", help="KernelCI build kernel git describe")
-    parser.add_argument("--config", help="configuration for the LAVA server")
-    parser.add_argument("--section", default="default", help="section in the LAVA config file")
+    parser.add_argument("--config", help="path to KernelCI configuration file")
+    parser.add_argument("--section", default="default", help="section in the KernelCI config file")
     parser.add_argument("--plans", nargs='+', required=True, help="test plan to create jobs for")
     parser.add_argument("--arch", help="specific architecture to create jobs for")
     parser.add_argument("--targets", nargs='+', help="specific targets to create jobs for")

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -68,7 +68,7 @@ def main(args):
         sys.exit(1)
     data = json.loads(response.content)
     builds = data['result']
-    print len(builds)
+    print("Number of builds: {}".format(len(builds)))
     jobs = []
     cwd = os.getcwd()
     for build in builds:

--- a/lava-v2-submit-jobs.py
+++ b/lava-v2-submit-jobs.py
@@ -13,10 +13,9 @@ import httplib
 
 from lib import utils
 from lib import configuration
+
 DEVICE_ONLINE_STATUS = ['idle', 'running', 'reserved']
-
-job_map = {}
-
+JOBS = {}
 
 def submit_jobs(connection):
     print "Fetching all devices from LAVA"
@@ -25,7 +24,7 @@ def submit_jobs(connection):
     all_device_types = connection.scheduler.all_device_types()
 
     print "Submitting Jobs to Server..."
-    for job in job_map:
+    for job in JOBS:
         try:
             with open(job, 'rb') as stream:
                 job_data = stream.read()
@@ -52,11 +51,10 @@ def submit_jobs(connection):
             print e
             continue
 
-
 def load_jobs(top):
     for root, dirnames, filenames in os.walk(top):
         for filename in fnmatch.filter(filenames, '*.yaml'):
-            job_map[os.path.join(root, filename)] = None
+            JOBS[os.path.join(root, filename)] = None
 
 def device_type_has_available(device_type, all_devices):
     for device in all_devices:
@@ -79,8 +77,10 @@ def main(args):
     print("Loading jobs from {}".format(jobs))
     load_jobs(jobs)
 
-    if job_map:
-        url = utils.validate_input(config.get("username"), config.get("token"), config.get("server"))
+    if JOBS:
+        start_time = time.time()
+        url = utils.validate_input(config.get("username"), config.get("token"),
+                                   config.get("server"))
         connection = utils.connect(url)
         submit_jobs(connection)
     exit(0)
@@ -88,7 +88,10 @@ def main(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", help="configuration for the LAVA server")
-    parser.add_argument("--jobs", help="absolute path to top jobs folder (default scans the whole cwd)", required=True)
+    parser.add_argument("--section", default="default",
+                        help="section in the LAVA config file")
+    parser.add_argument("--jobs", required=True,
+                        help="path to jobs directory (default is cwd)")
     parser.add_argument("--username", help="username for the LAVA server")
     parser.add_argument("--token", help="token for LAVA server api")
     parser.add_argument("--server", help="server url for LAVA server")

--- a/lava-v2-submit-jobs.py
+++ b/lava-v2-submit-jobs.py
@@ -75,11 +75,9 @@ def main(args):
     if config.get("repo"):
         retrieve_jobs(config.get("repo"))
 
-    if config.get("jobs"):
-        load_jobs(config.get("jobs"))
-        print "Loading jobs from top folder " + str(config.get("jobs"))
-    else:
-        load_jobs(os.getcwd())
+    jobs = config.get("jobs")
+    print("Loading jobs from {}".format(jobs))
+    load_jobs(jobs)
 
     if job_map:
         url = utils.validate_input(config.get("username"), config.get("token"), config.get("server"))
@@ -90,11 +88,10 @@ def main(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", help="configuration for the LAVA server")
-    parser.add_argument("--jobs", help="absolute path to top jobs folder (default scans the whole cwd)")
+    parser.add_argument("--jobs", help="absolute path to top jobs folder (default scans the whole cwd)", required=True)
     parser.add_argument("--username", help="username for the LAVA server")
     parser.add_argument("--token", help="token for LAVA server api")
     parser.add_argument("--server", help="server url for LAVA server")
     parser.add_argument("--repo", help="git repo for LAVA jobs")
-    parser.add_argument("--timeout", type=int, default=-1, help="polling timeout in seconds. default is -1.")
     args = vars(parser.parse_args())
     main(args)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,1 @@
+from device_map import device_map

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -28,6 +28,18 @@ metadata:
 {% block main %}
 device_type: {{ device['device_type'] }}
 
+{% if callback %}
+notify:
+  criteria:
+    status: finished
+  callback:
+    url: {{ api }}/callback/lava?lab_name={{ lab_name }}&status={STATUS}&status_string={STATUS_STRING}
+    method: POST
+    dataset: all
+    token: kernel-ci-callback
+    content-type: json
+{% endif %}
+
 job_name: {{ name }}
 timeouts:
   job:


### PR DESCRIPTION
This pull request has a few mixed commits from the staging repository:
https://github.com/kernelci/lava-ci-staging/releases/tag/kernelci-staging-20170621

In a nutshell:
* put the Jenkins jobs under source control
* add the first steps to enable the --callback option
* fix config file support

Merging this will require some changes to the Jenkins jobs configurations to call the shell scripts.

Associated build and boot results (reduced number of configs):
https://staging.kernelci.org/build/gtucker/branch/kernelci-test/kernel/kernelci-test-001-4-g44933f1e95d1/
https://lava.collabora.co.uk/scheduler/alljobs?length=25&search=kernelci-test