### PR TITLE
lava-v2-jobs-from-api: Require storage parameter

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -249,7 +249,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--token", help="KernelCI API Token")
     parser.add_argument("--api", help="KernelCI API URL")
-    parser.add_argument("--storage", help="KernelCI storage URL")
+    parser.add_argument("--storage", help="KernelCI storage URL", required=True)
     parser.add_argument("--lab", help="KernelCI Lab Name", required=True)
     parser.add_argument("--jobs", help="absolute path to top jobs folder")
     parser.add_argument("--tree", help="KernelCI build kernel tree", required=True)


### PR DESCRIPTION
Storage parameter is required using lava-v2-jobs-from-api.py
to generate proper yaml job files, require it in the command
line parser

Fixes: a9dc7f3012a5 KernelCI staging 20170621 (#91)
Signed-off-by: Loys Ollivier <lollivier@baylibre.com>