### PR TITLE
Fix rpi3, blacklists on v2, and dont boot test kselftest configs

### DIFF
--- a/lava-kernel-ci-job-creator.py
+++ b/lava-kernel-ci-job-creator.py
@@ -121,6 +121,8 @@ def create_jobs(base_url, kernel, plans, platform_list, targets, priority):
                     print '%s device type has been omitted. Skipping JSON creation.' % device_type
                 elif not any([x for x in defconfigs if x == arch_defconfig]) and plan != 'boot':
                     print '%s has been omitted from the %s test plan. Skipping JSON creation.' % (defconfig, plan)
+                elif 'kselftest' in defconfig and plan != 'kselftest':
+                    print "Skipping kselftest defconfig because plan was not kselftest"
                 else:
                     for template in device_templates:
                         job_name = tree + '-' + branch + '-' + kernel_version + '-' + arch + '-' + defconfig[:100] + '-' + platform_name + '-' + device_type + '-' + plan

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -69,7 +69,6 @@ def main(args):
     git_describe = args.get('describe')
     tree = args.get('tree')
     expected = int(args.get('defconfigs'))
-    kernel = tree
     headers = {
         "Authorization": token,
     }
@@ -165,17 +164,17 @@ def main(args):
                             elif "LPAE" in defconfig and not lpae:
                                 print "LPAE is not support on %s" % device_type
                                 continue
-                            elif any([x for x in device['kernel_blacklist'] if x in kernel]):
-                                print "kernel %s is blacklisted for device %s" % (kernel, device_type)
+                            elif any([x for x in device['kernel_blacklist'] if x in git_describe]):
+                                print "git_describe %s is blacklisted for device %s" % (git_describe, device_type)
                                 continue
-                            elif any([x for x in device['nfs_blacklist'] if x in kernel]) \
+                            elif any([x for x in device['nfs_blacklist'] if x in git_describe]) \
                                     and plan in ['boot-nfs', 'boot-nfs-mp']:
-                                print "kernel %s is blacklisted for NFS on device %s" % (kernel, device_type)
+                                print "git_describe %s is blacklisted for NFS on device %s" % (git_describe, device_type)
                                 continue
                             elif 'be_blacklist' in device \
-                                    and any([x for x in device['be_blacklist'] if x in kernel]) \
+                                    and any([x for x in device['be_blacklist'] if x in git_describe]) \
                                     and plan in ['boot-be']:
-                                print "kernel %s is blacklisted for BE on device %s" % (kernel, device_type)
+                                print "git_describe %s is blacklisted for BE on device %s" % (git_describe, device_type)
                                 continue
                             elif (arch_defconfig not in plan_defconfigs) and (plan != "boot"):
                                 print "defconfig %s not in test plan %s" % (arch_defconfig, plan)
@@ -184,6 +183,8 @@ def main(args):
                                 print "device_type %s is not in targets %s" % (device_type, targets)
                             elif arch == 'x86' and dtb == 'x86-32' and 'i386' not in arch_defconfig:
                                 print "%s is not a 32-bit x86 build, skipping for 32-bit device %s" % (defconfig, device_type)
+                            elif 'kselftest' in defconfig and plan != 'kselftest':
+                                print "Skipping kselftest defconfig because plan was not kselftest"
                             else:
                                 for template in device['templates']:
                                     short_template_file = plan + '/' + str(template)
@@ -194,6 +195,7 @@ def main(args):
                                         nfsrootfs_url = None
                                         initrd_url = None
                                         callback_name = 'lava/boot' if 'boot' in plan else 'lava/test'
+                                        context = device['context'] if 'context' in device else None
                                         if dtb_full.endswith('.dtb'):
                                             dtb_url = base_url + "dtbs/" + dtb_full
                                             platform = dtb[:-4]
@@ -266,7 +268,8 @@ def main(args):
                                                'callback': args.get('callback'),
                                                'api': api,
                                                'lab_name': lab_name,
-                                               'callback_name': callback_name
+                                               'callback_name': callback_name,
+                                               'context': context,
                                         }
                                         jobs.append(job)
             else:

--- a/lib/device_map.py
+++ b/lib/device_map.py
@@ -78,10 +78,11 @@ bcm2837_rpi_3_b = {'device_type': 'bcm2837-rpi-3-b',
                'defconfig_blacklist': ['allnoconfig',
                                        'allmodconfig'],
                'arch_blacklist': ['arm'],
-               'kernel_blacklist': [],
+               'kernel_blacklist': ['v4.13-', 'v4.14-rc1', 'v4.14-rc5', 'for-4.15', 'v3.', '4.4-', '4.9-'],
                'nfs_blacklist': [],
                'lpae': False,
                'fastboot': False,
+               'context': {'console_device': 'ttyS1'},
                'mach': 'bcm'}
 
 bcm4708_smartrg_sr400ac = {'device_type': 'bcm4708-smartrg-sr400ac',

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -31,6 +31,13 @@ metadata:
 {% block main %}
 device_type: {{ device_type }}
 
+{% if context %}
+context:
+{%- for key, value in context.items() %}
+  {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+
 {% if callback %}
 notify:
   criteria:


### PR DESCRIPTION
The rpi3 has been blacklisted to as many old kernels as I could
find, and the console setting is now overriden using context.
V2 blacklisting was not working, it was being checked against the
tree name not git describe.
And do not boot test kselftest config.